### PR TITLE
fix(ci): improve Playwright caching and deploy dashboard reliability

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -22,12 +22,25 @@ jobs:
           ref: main
 
       - name: Download dashboard artifact from triggering run
+        id: download
         if: github.event_name == 'workflow_run'
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: dashboard-data
           path: docs/
           run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fallback to latest dashboard artifact
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && steps.download.outcome == 'failure')
+        run: |
+          RUN_ID=$(gh api repos/${{ github.repository }}/actions/workflows/playwright.yml/runs?per_page=1&status=completed -q '.workflow_runs[0].id')
+          if [ -n "$RUN_ID" ]; then
+            gh run download "$RUN_ID" -n dashboard-data -D docs/ || echo "No artifact found"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -46,6 +59,7 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+          git pull --rebase origin main
           git add docs/dashboard-data.json
           git diff --staged --quiet || git commit -m "Update dashboard data [skip ci]"
           git push

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,11 +30,20 @@ jobs:
       - run: npm ci
 
       - uses: actions/cache@v4
+        id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
-      - run: npx playwright install --with-deps
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Install Playwright system dependencies only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
 
       - name: Run Playwright tests
         run: npx playwright test


### PR DESCRIPTION
## Summary
- Add conditional Playwright browser install based on cache hit (skip full install when cache exists)
- Add fallback artifact download for deploy dashboard when specific run-id fails
- Add git pull --rebase before push to prevent merge conflicts on rapid successive runs