### PR TITLE
feat(auth): storageState-based persona fixtures — remove beforeEach login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ playwright-report/
 dist/
 build/
 .DS_Store
+.playwright-auth/

--- a/fixtures/index.ts
+++ b/fixtures/index.ts
@@ -1,16 +1,45 @@
+import { test as base, Page } from '@playwright/test';
 import { AuthPage } from '../pages/auth/AuthPage';
-import { test as base } from '@playwright/test';
 
 // POMs are added here as KlikAgent generates and reviews them.
 // After each PR is merged, import the new POM and register it below.
 
 type Fixtures = {
+  // Auth — use for login-page tests (form validation, error states, etc.)
   authPage: AuthPage;
+
+  // Persona fixtures — provide a pre-authenticated Page via storageState.
+  // Use these in feature tests instead of beforeEach login:
+  //   test('...', async ({ asPatient }) => { await asPatient.goto('/dashboard'); ... })
+  asPatient: Page;
+  asDoctor: Page;
+  asAdmin: Page;
 };
 
 export const test = base.extend<Fixtures>({
   authPage: async ({ page }, use) => {
     await use(new AuthPage(page));
+  },
+
+  asPatient: async ({ browser }, use) => {
+    const ctx = await browser.newContext({ storageState: '.playwright-auth/patient.json' });
+    const page = await ctx.newPage();
+    await use(page);
+    await ctx.close();
+  },
+
+  asDoctor: async ({ browser }, use) => {
+    const ctx = await browser.newContext({ storageState: '.playwright-auth/doctor.json' });
+    const page = await ctx.newPage();
+    await use(page);
+    await ctx.close();
+  },
+
+  asAdmin: async ({ browser }, use) => {
+    const ctx = await browser.newContext({ storageState: '.playwright-auth/admin.json' });
+    const page = await ctx.newPage();
+    await use(page);
+    await ctx.close();
   },
 });
 

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -1,0 +1,34 @@
+import { chromium, FullConfig } from '@playwright/test';
+import { personas } from './config/personas';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Global setup — runs once before the entire test suite.
+ * Logs in as each persona and saves storageState to .playwright-auth/{persona}.json.
+ * Tests load the saved state via asPatient / asDoctor / asAdmin fixtures — no login boilerplate needed.
+ */
+export default async function globalSetup(config: FullConfig) {
+  const baseURL = config.projects[0]?.use?.baseURL ?? 'https://app.testingwithekki.com';
+  const authDir = path.join(process.cwd(), '.playwright-auth');
+  fs.mkdirSync(authDir, { recursive: true });
+
+  const browser = await chromium.launch();
+
+  for (const [name, persona] of Object.entries(personas)) {
+    const context = await browser.newContext({ baseURL });
+    const page = await context.newPage();
+
+    await page.goto('/login');
+    await page.getByTestId('email-input').fill(persona.email);
+    await page.getByTestId('password-input').fill(persona.password);
+    await page.getByTestId('login-submit').click();
+    await page.waitForURL(/\/dashboard/);
+
+    const stateFile = path.join(authDir, `${name}.json`);
+    await context.storageState({ path: stateFile });
+    await context.close();
+  }
+
+  await browser.close();
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   testDir: './tests',
   timeout: 30000,
   workers: process.env.CI ? 3 : undefined,
+  globalSetup: require.resolve('./global-setup'),
   use: {
     baseURL: 'https://app.testingwithekki.com',
     headless: true,


### PR DESCRIPTION
## Summary

- **global-setup.ts** — runs once before the suite; logs in as each persona (`patient`, `doctor`, `admin`) and saves `.playwright-auth/{persona}.json`
- **fixtures/index.ts** — adds `asPatient`, `asDoctor`, `asAdmin` fixtures that load saved storageState and provide a pre-authenticated `Page`
- **playwright.config.ts** — wires up `globalSetup`
- **.gitignore** — excludes `.playwright-auth/`

## Why

Login happened before every test via `beforeEach` → `authPage.gotoLogin()` + `authPage.login()`. This was:
- 3 lines of boilerplate in every feature spec
- A source of bugs (forgetting `gotoLogin()` before `login()`)
- Slow (3 workers × N tests = N login round trips per run)

## New pattern

```typescript
test('patient sees sidebar link', async ({ asPatient }) => {
  await asPatient.goto('/dashboard');
  const pom = new BookAppointmentPage(asPatient);
  await pom.expectBookAppointmentSidebarLinkVisible();
});
```

`authPage` fixture remains for auth-specific tests (login form, validation errors, etc.).

## Test plan
- [ ] Global setup completes without error (3 auth state files created)
- [ ] Existing auth tests still pass using `authPage` fixture
- [ ] Feature tests use `asPatient`/`asDoctor`/`asAdmin` with no `beforeEach`

🤖 Generated with [Claude Code](https://claude.com/claude-code)